### PR TITLE
Modification June 2019 by M. Leocmach /C. Ybert

### DIFF
--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -273,6 +273,11 @@ class SerieHeader:
         return self._dimensions
 
     def hasZ(self):
+        """
+        Method: Check if current serie includes Z stacking
+        
+        Return: Boolean value
+        """
         for d in self.getDimensions():
             if dimName[int(d.getAttribute("DimID"))] == "Z":
                 return True
@@ -341,9 +346,25 @@ class SerieHeader:
         return self._numberOfElements
 
     def getVoxelSize(self, dimension):
+        """
+        Method: Use getScannerSetting() to return the resolution
+        
+        arg:: dimension is an integer according to the dimName dictionnary {1: X, 2: Y, 3: Z}
+        
+        Return: Voxel size of specified axis (float)
+
+        """
         return float(self.getScannerSetting("dblVoxel%s" % dimName[dimension]))
 
     def getZXratio(self):
+        """
+        Method: Calculate for the current Serie the ratio between Vertical (Z) and Horizontal (X) image resolutions. Looks for the information either in
+                    - 'ScannerSettingRecord' (resolution)
+                    - or in 'DimensionDescription' (total size / pixel number)
+        
+        Return: Z/X resolution ratio (float). Return 1.0 if the current Serie has no Z-stack.
+               
+        """
         setting_records = self.root.getElementsByTagName('ScannerSettingRecord')
         dimension_descriptions = self.root.getElementsByTagName('DimensionDescription')
         if self.hasZ():
@@ -383,7 +404,14 @@ class SerieHeader:
         return self._duration
 
     def getTimeLapse(self):
-        """Get an estimate of the average time lapse between two frames in seconds"""
+        """
+        Method: Get an estimate of the average time lapse between two frames in seconds
+
+        Return: estimated Lag time in seconds (float)
+        
+        warning:: Note that this value is accessible directly via getScannerSetting('nDelayTime_ms')
+           
+        """
         if self.getNbFrames() == 1:
             return 0
         else:
@@ -442,6 +470,13 @@ class SerieHeader:
         return getattr(self, '_' + dim)
 
     def chooseChannel(self):
+        """
+        Method: Interactive selection of the channel for the current serie.
+        
+        Print the Serie name `chosen_serie.getName() and a list of all channels specifying: index, Color
+        Promt for selecting a channel index.
+        
+        """
         st = "Serie: %s\n" % self.getName()
         for i, c in enumerate(self.getChannels()):
             st += "(%i) %s\n" % (i, channelTag[int(c.getAttribute("ChannelTag"))])
@@ -490,11 +525,19 @@ class SerieHeader:
         return self._boxShape
 
     def getFrameShape(self):
-        """Shape of the frame (nD image) in C order, that is Z,Y,X"""
+        """
+        Method: Get the Shape of the frame (nD image) in C order, that is Z,Y,X 
+        
+        Return: list of integers of axis length in Z, Y, X order (reverse as in .getBoxShape())
+        """
         return self.getBoxShape()[::-1]
 
     def get2DShape(self):
-        """size of the two first spatial dimensions, in C order, e.g. Y,X"""
+        """
+        Method: Get the Shape of an image using the two first spatial dimensions, in C order, e.g. Y,X
+        
+        Return: list of integers of axis length
+        """
         return self.getBoxShape()[:2][::-1]
 
     def getNbPixelsPerFrame(self):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -564,7 +564,11 @@ class SerieHeader:
 
 
 def get_xml(lif_name):
-    """Extract the XML header from LIF file and save it"""
+    """
+    Function: Extract the XML header from LIF file and save it. Generated .xml file can be opened in a Web Browser
+    
+    Use to examine the global architecture and the keywords associated with usefull information, to use with getXXX() methods
+    """
     with open(lif_name, "rb") as f:
         memBlock, trash, testBlock = struct.unpack("iic", f.read(9))
         if memBlock != 112:

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -160,6 +160,13 @@ class Header:
         return self._seriesHeaders
 
     def chooseSerieIndex(self):
+        """
+        Method: Interactive selection of the desired serie.
+        
+        Print a list of all Series specifying: index, Name, Channel number and Tag, and stack dimensions X, Y, Z, T,...
+        Promt for selecting a Serie number.
+        
+        """
         st = "Experiment: %s\n" % self.getName()
         for i, s in enumerate(self.getSeriesHeaders()):
             # s = Serie(serie)
@@ -189,6 +196,14 @@ class Header:
         return r
 
     def chooseSerieHeader(self):
+        """
+        Method: Interactive selection of the desired serie header.
+        
+        Print a list of all Series specifying: index, Name, Channel number and Tag, and stack dimensions X, Y, Z, T,...
+        Promt for selecting a Serie number.
+        
+        """
+
         return self.getSeriesHeaders()[self.chooseSerieIndex()]
 
     def __iter__(self):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -47,7 +47,13 @@ channelTag = ["Gray", "Red", "Green", "Blue"]
 
 
 class Header:
-    """The XML header of a Leica LIF files"""
+    """
+    The XML header of a Leica LIF files
+    
+    Attributes:: are all semi-private (should only be accessed from a method getXXX()) 
+                 as values are not supposed to be changed (they correspond to the *fixed* experimental conditions)
+                 _version, _name, _seriesHeaders, 
+    """
 
     def __init__(self, xmlHeaderFileName, quick=True):
         if sys.version_info > (3, 0):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -118,9 +118,13 @@ class Header:
         self.xmlHeader = parse(lightXML)
 
     def getVersion(self):
-        if not hasattr(self, '__version'):
-            self.__version = self.xmlHeader.documentElement.getAttribute("Version")
-        return int(self.__version)
+        """
+        Method: Get the version of the Data Container Header
+        Semi-private attribute `_version`
+        """
+        if not hasattr(self, '_version'):
+            self._version = self.xmlHeader.documentElement.getAttribute("Version")
+        return int(self._version)
 
     def getName(self):
         if not hasattr(self, '__name'):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -674,7 +674,11 @@ class Reader(Header):
 
 
 class Serie(SerieHeader):
-    """One on the datasets in a lif file"""
+    """
+    One of the datasets (Serie) in a .lif file
+    
+    Methods: 
+    """
 
     def __init__(self, serieElement, f, offset):
         self.f = f
@@ -682,6 +686,11 @@ class Serie(SerieHeader):
         self.root = serieElement
 
     def getOffset(self, **dimensionsIncrements):
+        """
+        Method: Get the Frame Offset
+        
+        kwargs:: Time, Channel or data type. Default to `channel=0, T=0, dtype=np.uint8`
+        """
         of = 0
         for d, b in dimensionsIncrements.items():
             of += self.getBytesInc(d) * b
@@ -690,13 +699,24 @@ class Serie(SerieHeader):
         return self.__offset + of
 
     def getChannelOffset(self, channel):
+        """
+        Method: Get the Channel Offset
+        
+        arg:: channel (int)
+        """
         channels = self.getChannels()
         channel_node = channels[channel]
         of = int(channel_node.getAttribute('BytesInc'))
         return of
 
     def get2DSlice(self, **dimensionsIncrements):
-        """Use the two first dimensions as image dimension. Axis are in C order (last index is X)."""
+        """
+        Method: Use the two first dimensions as image dimension (XY, XZ, YZ). Axis are in C order (last index is X).
+        
+        Return: Image as numpy array with the axis in ZY, ZX, or YX order
+        
+        warning:: See dtype argument; might not support 16bits encoding
+        """
         for d in self.getDimensions()[:2]:
             if dimName[int(d.getAttribute("DimID"))] in dimensionsIncrements:
                 raise Exception('You can\'t set %s in serie %s' % (
@@ -713,7 +733,9 @@ class Serie(SerieHeader):
         ).reshape(shape)
 
     def get2DString(self, **dimensionsIncrements):
-        """Use the two first dimensions as image dimension"""
+        """
+        Use the two first dimensions as image dimension
+        """
         for d in self.getDimensions()[:2]:
             if dimName[int(d.getAttribute("DimID"))] in dimensionsIncrements:
                 raise Exception('You can\'t set %s in serie %s' % (

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -330,6 +330,26 @@ class SerieHeader:
                     setattr(self, '_' + identifier, c.getAttribute("Variant"))
                     break
         return getattr(self, '_' + identifier)
+    
+    def getFilterSetting(self, objectName):
+        """
+        Method: Access to the value of one of the Experimental Condition elements under `FilterSettingRecord TagName`
+        Semi-private attribute `_"objectName"`
+        
+        arg:: objectName (string) as the name of the Object looked for.
+        
+              Refer to xml file for a list of relevant objectName: e.g. 'Scan Head' yields information about scanner
+        
+        return: Unlike identifier in getScannerSetting, a single objectname has multiple occurences, 
+                hence getFilterSetting returns a dictionnary of all {Attributes: Variant}, with values 'Variant' being strings 
+        """
+        if not hasattr(self, '_' + objectName):
+            obj = dict()
+            for c in self.root.getElementsByTagName("FilterSettingRecord"):
+                if c.getAttribute("ObjectName") == objectName:
+                    obj[c.getAttribute("Attribute")] = c.getAttribute("Variant")
+            setattr(self,  '_' + objectName, obj)
+        return getattr(self, '_' +  objectName)
 
     def getNumberOfElements(self):
         """

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -137,7 +137,12 @@ class Header:
         return self._name
 
     def getSeriesHeaders(self):
-        if not hasattr(self, '__seriesHeaders'):
+        """
+        Method: Get the Series Headers of all series contained in the .lif file
+        Semi-private attribute `_seriesHeaders`
+        """
+
+        if not hasattr(self, '_seriesHeaders'):
             root = self.xmlHeader.documentElement
             headers = []
             counter = 0
@@ -151,8 +156,8 @@ class Header:
                     if size:
                         if int(size) > 0:
                             headers.append(SerieHeader(element))
-            self.__seriesHeaders = headers
-        return self.__seriesHeaders
+            self._seriesHeaders = headers
+        return self._seriesHeaders
 
     def chooseSerieIndex(self):
         st = "Experiment: %s\n" % self.getName()

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -127,10 +127,14 @@ class Header:
         return int(self._version)
 
     def getName(self):
-        if not hasattr(self, '__name'):
-            self.__name = self.xmlHeader.documentElement. \
+        """
+        Method: Get the name of current lif file (without extension .lif)
+        Semi-private attribute `_name`
+        """
+        if not hasattr(self, '_name'):
+            self._name = self.xmlHeader.documentElement. \
                 getElementsByTagName('Element')[0].getAttribute("Name")
-        return self.__name
+        return self._name
 
     def getSeriesHeaders(self):
         if not hasattr(self, '__seriesHeaders'):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -223,30 +223,54 @@ class SerieHeader:
         self.root = serieElement
 
     def getName(self):
-        if not hasattr(self, '__name'):
-            self.__name = self.root.getAttribute("Name")
-        return self.__name
+        """
+        Method: Get the Name of the Serie
+        Semi-private attribute `_name`
+        """
+        if not hasattr(self, '_name'):
+            self._name = self.root.getAttribute("Name")
+        return self._name
 
     def isPreview(self):
-        if not hasattr(self, '__isPreview'):
-            self.__isPreview = 0
+        if not hasattr(self, '_isPreview'):
+            self._isPreview = 0
             for c in self.root.getElementsByTagName("Attachment"):
                 if c.getAttribute("Name") == "PreviewMarker":
-                    self.__isPreview = bool(c.getAttribute("isPreviewImage"))
+                    self._isPreview = bool(c.getAttribute("isPreviewImage"))
                     break
-
-        return self.__isPreview
+        return self._isPreview
 
     def getChannels(self):
-        if not hasattr(self, '__channels'):
-            self.__channels = self.root.getElementsByTagName("ChannelDescription")
-        return self.__channels
+        """
+        Method: Extract the DOM elements describing the used channels.
+        Semi-private attribute `_channels`
+        
+        Return: List of DOM elements
+        
+        Use: To recover information contained in `chosen_serie.getChannels()`, iterate over the elements and apply `.getAttribute('Keyword')` method
+        
+        Keywords: Refer to xml file for a list of relevant Keywords. Examples: DataType, ChannelTag, Resolution, NameOfMeasuredQuantity, Min, Max, Unit, 
+                  LUTName, IsLUTInverted, BytesInc, BitInc
+        """
+        if not hasattr(self, '_channels'):
+            self._channels = self.root.getElementsByTagName("ChannelDescription")
+        return self._channels
 
     def getDimensions(self):
-        if not hasattr(self, '__dimensions'):
-            self.__dimensions = self.root.getElementsByTagName(
+        """
+        Method: Extract the DOM elements describing the used channels.
+        Semi-private attribute `_dimensions`
+                
+        Return: List of DOM elements
+        
+        Use: To recover information contained in `chosen_serie.getDimensionss()`, iterate over the elements and apply `.getAttribute('Keyword') method
+        
+        Keywords: Refer to xml file for a list of relevant Keywords. Examples: DimID, NumberOfElements, Origin, Length, Unit, BitInc, BytesInc
+        """
+        if not hasattr(self, '_dimensions'):
+            self._dimensions = self.root.getElementsByTagName(
                 "DimensionDescription")
-        return self.__dimensions
+        return self._dimensions
 
     def hasZ(self):
         for d in self.getDimensions():
@@ -255,35 +279,66 @@ class SerieHeader:
         return False
 
     def getMemorySize(self):
-        if not hasattr(self, '__memorySize'):
+        """
+        Method: Get the Memory size of the current Serie
+        Semi-private attribute `_memorySize`
+        
+        Return: Memory size as int
+        """
+        if not hasattr(self, '_memorySize'):
             for m in self.root.getElementsByTagName("Memory"):
                 # to ensure the Memory node is the child of root
                 if m.parentNode is self.root:
-                    self.__memorySize = int(m.getAttribute("Size"))
-        return self.__memorySize
+                    self._memorySize = int(m.getAttribute("Size"))
+        return self._memorySize
 
     def getResolution(self, channel):
-        if not hasattr(self, '__resolusion'):
-            self.__resolusion = int(
+        """
+        Method: Get the BitDepth Resolution of a given Channel using .getChannels() method
+        Semi-private attribute `_resolution`
+
+        arg:: channel number (int)
+        
+        Return: Bit Depth resolution as int
+        """
+        if not hasattr(self, '_resolution'):
+            self._resolution = int(
                 self.getChannels()[channel].getAttribute("Resolution")
             )
-        return self.__resolusion
+        return self._resolution
 
     def getScannerSetting(self, identifier):
-        if not hasattr(self, '__' + identifier):
+        """
+        Method: Access to the value of one of the Experimental Condition elements under ScannerSettingRecord TagName
+        Semi-private attribute `_"identifier"`
+        
+        arg:: identifier (string) as the name of the Attribute looked for.
+        
+              Refer to xml file for a list of relevant identifier: dblPinhole, dblSizeX, dblSizeY, dblVoxelX, dblVoxelY, dblZoom, 
+              nAccumulation, nAverageFrame, nAverageLine, nChannels, nDelayTime_ms, nLineAccumulation, nRepeatActions, ...
+        
+        return: The value ('Variant') of the required Attribute ('identifier') as a *string* 
+        """
+        if not hasattr(self, '_' + identifier):
             for c in self.root.getElementsByTagName("ScannerSettingRecord"):
                 if c.getAttribute("Identifier") == identifier:
-                    setattr(self, '__' + identifier, c.getAttribute("Variant"))
+                    setattr(self, '_' + identifier, c.getAttribute("Variant"))
                     break
-        return getattr(self, '__' + identifier)
+        return getattr(self, '_' + identifier)
 
     def getNumberOfElements(self):
-        if not hasattr(self, '__numberOfElements'):
-            self.__numberOfElements = [
+        """
+        Method: Use .getDimensions() method to extact the data dimensions along all axis in order X, Y, Z, T, ...
+        Semi-private attribute `_numberOfElements`
+        
+        Result: List of integers
+        """
+        if not hasattr(self, '_numberOfElements'):
+            self._numberOfElements = [
                 int(d.getAttribute("NumberOfElements")) \
                 for d in self.getDimensions()
             ]
-        return self.__numberOfElements
+        return self._numberOfElements
 
     def getVoxelSize(self, dimension):
         return float(self.getScannerSetting("dblVoxel%s" % dimName[dimension]))
@@ -314,13 +369,18 @@ class SerieHeader:
             return 1.0
 
     def getTotalDuration(self):
-        """Get total duration of the experiment"""
-        if not hasattr(self, '__duration'):
-            self.__duration = 0.0
+        """
+        Method: Get total duration of the experiment using the .getDimensions() method
+        Semi-private attribute `_duration`
+        
+        Return: duration (float) in seconds
+        """
+        if not hasattr(self, '_duration'):
+            self._duration = 0.0
             for d in self.getDimensions():
                 if dimName[int(d.getAttribute("DimID"))] == "T":
-                    self.__duration = float(d.getAttribute("Length"))
-        return self.__duration
+                    self._duration = float(d.getAttribute("Length"))
+        return self._duration
 
     def getTimeLapse(self):
         """Get an estimate of the average time lapse between two frames in seconds"""
@@ -361,17 +421,25 @@ class SerieHeader:
         return self.__relTimeStamps
 
     def getBytesInc(self, dimension):
+        """
+        Method: Get the ByteIncrement of a given dimension in the Serie.
+        Semi-private attribute `_"dim"`, with "dim" a string = X, Y, Z, T
+        
+        arg:: dimension either as a string or as its key (integer) in dimName = {1: "X", 2: "Y", 3: "Z", 4: "T", ...}
+        
+        Return: BytesIncr as integer
+        """
         # todo: consider channels
         if isinstance(dimension, int):
             dim = dimName[dimension]
         else:
             dim = dimension
-        if not hasattr(self, '__' + dim):
-            setattr(self, '__' + dim, 0)
+        if not hasattr(self, '_' + dim):
+            setattr(self, '_' + dim, 0)
             for d in self.getDimensions():
                 if dimName[int(d.getAttribute("DimID"))] == dim:
-                    setattr(self, '__' + dim, int(d.getAttribute("BytesInc")))
-        return getattr(self, '__' + dim)
+                    setattr(self, '_' + dim, int(d.getAttribute("BytesInc")))
+        return getattr(self, '_' + dim)
 
     def chooseChannel(self):
         st = "Serie: %s\n" % self.getName()
@@ -391,23 +459,35 @@ class SerieHeader:
         return r
 
     def getNbFrames(self):
-        if not hasattr(self, '__nbFrames'):
-            self.__nbFrames = 1
+        """
+        Method: Get the number of frames in the Serie (acquisition at successive times)
+        Semi-private attribute `_nbFrames`
+        
+        Return: number of frames (integer)
+        """
+        if not hasattr(self, '_nbFrames'):
+            self._nbFrames = 1
             for d in self.getDimensions():
                 if d.getAttribute("DimID") == "4":
-                    self.__nbFrames = int(d.getAttribute("NumberOfElements"))
-        return self.__nbFrames
+                    self._nbFrames = int(d.getAttribute("NumberOfElements"))
+        return self._nbFrames
 
     def getBoxShape(self):
-        """Shape of the field of view in the X,Y,Z order."""
-        if not hasattr(self, '__boxShape'):
+        """
+        Method: Get the Shape (spatial) of a frame 
+        Semi-private attribute: _boxShape
+        
+        Return: a list integers [length axis 1, length axis 2, ... ] ordered according to axis number (X, Y, Z)
+        
+        """
+        if not hasattr(self, '_boxShape'):
             dims = {
                 int(d.getAttribute('DimID')): int(d.getAttribute("NumberOfElements"))
                 for d in self.getDimensions()
             }
-            # ensure dimensions are sorted, keep only spatial dimensions
-            self.__boxShape = [s for d, s in sorted(dims.items()) if d < 4]
-        return self.__boxShape
+            # ensure dimensions are sorted (unlike dictionnaries...), keep only spatial dimensions
+            self._boxShape = [s for d, s in sorted(dims.items()) if d < 4]
+        return self._boxShape
 
     def getFrameShape(self):
         """Shape of the frame (nD image) in C order, that is Z,Y,X"""
@@ -418,14 +498,26 @@ class SerieHeader:
         return self.getBoxShape()[:2][::-1]
 
     def getNbPixelsPerFrame(self):
-        if not hasattr(self, '__nbPixelsPerFrame'):
-            self.__nbPixelsPerFrame = np.prod(self.getBoxShape())
-        return self.__nbPixelsPerFrame
+        """
+        Method: Get the total number of pixels in a frame of shape .getBoxShape()
+        Semi-private attribute: _nbPixelsPerFrame
+        
+        Return: total number of pixels (integer) 
+        """
+        if not hasattr(self, '_nbPixelsPerFrame'):
+            self._nbPixelsPerFrame = np.prod(self.getBoxShape())
+        return self._nbPixelsPerFrame
 
     def getNbPixelsPerSlice(self):
-        if not hasattr(self, '__nbPixelsPerSlice'):
-            self.__nbPixelsPerSlice = np.prod(self.get2DShape())
-        return self.__nbPixelsPerSlice
+        """
+        Method: Get the total number of pixels in a Slice of shape .get2DShape()
+        Semi-private attribute: _nbPixelsPerSlice
+        
+        Return: total number of pixels (integer) 
+        """
+        if not hasattr(self, '_nbPixelsPerSlice'):
+            self._nbPixelsPerSlice = np.prod(self.get2DShape())
+        return self._nbPixelsPerSlice
 
 
 def get_xml(lif_name):

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -5,6 +5,37 @@
 #  with different python version and confocal machines
 #  Since its' original version use GPL License, it's restricted GPL as well
 
+
+#    Modification June 2019 by M. Leocmach /C. Ybert:
+#
+#        0- Note about good practices: semi-private attributes should only be accessed from a method getXXX(). Semi-privacy is chosen here to emphasize 
+#           that values are not supposed to be changed (they correspond to the *fixed* experimental conditions)
+#
+#        1- Limit read_lif to its main purpose (remove analysis functions getNeighbourhood() and getRadius, and associated library import)
+#        2- Add a getFilterSetting method to SerieHeader Class
+#        3- Modify Header.parse method (remove initial storage of all timestamps)
+#        5- Expand (a bit) the function description
+#        6- Move all double underscore attributes to simple underscore (semi-private ones) and corrected uneffective hasattr() tests
+#        7- Remove get2DImage() methods
+#        8- Add a getFrame2D() method to extract a 2D image. As for getFrame() it lacks proper conditional testing to accomodate (or report error)
+#           depending on the type of data (XYT, XYZT, ...). It is based on the inner loop in getFrame so that it might be possible to
+#           rewrite getFrame() using getFrame2D().
+#
+#
+#        BUGS: - getMetadata() doesn't support XY frames (no z)
+#              - getFrame() doesn't support XY frames (no z)
+#              - get2DStrings() doesn't support XY frames (no z)
+#              - enumByFrame() and enumBySlice() lacks some conditional testing against the data frame type
+#
+#
+#        ToDo: - Correct Bugs
+#              - Convert TimeStamps into seconds
+#              - getZXratio it would be more consistent to use getDimensions() to obtain the information
+#              - Automatic type conversion of SeriesHeader data (in ScannerSetting and FilterSetting) using the VariantType data from VisualBasic
+#                {0: Empty, 1: Null, 2: Short, 3: integer, 4: single, 5: double, 6: currency, 7: date, 8: string, 9: object, 10: error
+#                 11: boolean, 12: variant, 13: dataObject, 14: decimal, 17: byte, 18: char, 20: long, 36: UserDefined, 8192: array}
+
+
 # ============== origional information ====================
 #
 #    Copyright 2009 Mathieu Leocmach

--- a/read_lif/read_lif.py
+++ b/read_lif/read_lif.py
@@ -582,7 +582,15 @@ def get_xml(lif_name):
 
 
 class Reader(Header):
-    """Reads Leica LIF files"""
+    """
+    Reads Leica LIF files
+    
+    Methods: getSeries(), chooseSeries(), __init__(), __iter__(), __readMemoryBlockHeader()
+    
+    Semi-Private Attribute:: _series
+                 
+
+    """
 
     def __init__(self, lifFile, quick=True):
         # open file and find it's size
@@ -641,13 +649,24 @@ class Reader(Header):
         return memorysize
 
     def getSeries(self):
-        if not hasattr(self, '__series'):
-            self.__series = [
+        """
+        Method: Get the experimental Series from the raw .lif file
+        Semi-Private Attribute: _series
+        
+        Return: a List of class Serie objects
+        """
+        if not hasattr(self, '_series'):
+            self._series = [
                 Serie(s.root, self.f, self.offsets[i]) for i, s in enumerate(self.getSeriesHeaders())
             ]
-        return self.__series
+        return self._series
 
     def chooseSerie(self):
+        """
+        Method: use .chooseSerieIndex() inherited Header method to interactively choose a Serie using .getSeries()
+        
+        Return: the selected class Serie object
+        """
         return self.getSeries()[self.chooseSerieIndex()]
 
     def __iter__(self):


### PR DESCRIPTION
Modification June 2019 by M. Leocmach /C. Ybert:

1. Note about good practices: semi-private attributes should only be accessed from a method getXXX(). Semi-privacy is chosen here to emphasize that values are not supposed to be changed (they correspond to the *fixed* experimental conditions)
2. Limit read_lif to its main purpose (remove analysis functions getNeighbourhood() and getRadius, and associated library import)
3. Add a getFilterSetting method to SerieHeader Class
4. Modify Header.parse method (remove initial storage of all timestamps)
5. Expand (a bit) the function description
6. Move all double underscore attributes to simple underscore (semi-private ones) and corrected uneffective hasattr() tests
7. Remove get2DImage() methods
8. Add a getFrame2D() method to extract a 2D image. As for getFrame() it lacks proper conditional testing to accomodate (or report error) depending on the type of data (XYT, XYZT, ...). It is based on the inner loop in getFrame so that it might be possible to rewrite getFrame() using getFrame2D().
